### PR TITLE
Fix default header title

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,3 +1,3 @@
-export default function Header({ title }) {
+export default function Header({ title = 'Default title' }) {
   return <h1 className="title">{title}</h1>
 }


### PR DESCRIPTION
## Summary
- add a fallback title so Header always renders text

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe38515088322960f3f983f264f12